### PR TITLE
changed book model field to use DATEONLY

### DIFF
--- a/app/models/book.model.js
+++ b/app/models/book.model.js
@@ -1,4 +1,3 @@
-
 module.exports = (sequelize, Sequelize) => {
   const Book = sequelize.define("book", {
     id: {
@@ -16,7 +15,7 @@ module.exports = (sequelize, Sequelize) => {
       allowNull: false,
     },
     date: {
-      type: Sequelize.DATE,
+      type: Sequelize.DATEONLY,
       allowNull: true,
     },
     cover: {


### PR DESCRIPTION
### Change book date field
- Changed book model date field from Sequelize.DATE
 to Sequelize.DATEONLY
- Solves invalid date entry error in when creating/editing Book